### PR TITLE
feat: add icon prop for use when in React

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,10 @@ export namespace Components {
          */
         "color"?: string;
         /**
+          * This a combination of both `name` and `src`. If a `src` url is detected it will set the `src` property. Otherwise it assumes it's a built-in named SVG and set the `name` property.
+         */
+        "icon"?: any;
+        /**
           * The name of the icon to use from the built-in set.
          */
         "name"?: string;
@@ -43,6 +47,10 @@ declare namespace LocalJSX {
           * The color of the icon
          */
         "color"?: string;
+        /**
+          * This a combination of both `name` and `src`. If a `src` url is detected it will set the `src` property. Otherwise it assumes it's a built-in named SVG and set the `name` property.
+         */
+        "icon"?: any;
         /**
           * The name of the icon to use from the built-in set.
          */

--- a/src/components/pds-icon/pds-icon.tsx
+++ b/src/components/pds-icon/pds-icon.tsx
@@ -26,6 +26,13 @@ export class PdsIcon {
   @Prop() color?: string;
 
   /**
+   * This a combination of both `name` and `src`. If a `src` url is detected
+   * it will set the `src` property. Otherwise it assumes it's a built-in named
+   * SVG and set the `name` property.
+   */
+  @Prop() icon?: any;
+
+  /**
    * The name of the icon to use from
    * the built-in set.
    */
@@ -79,6 +86,7 @@ export class PdsIcon {
   }
 
   @Watch('name')
+  @Watch('icon')
   loadIcon() {
     if (Build.isBrowser && this.isVisible) {
       const url = getUrl(this);
@@ -91,7 +99,7 @@ export class PdsIcon {
       }
     }
 
-    const label = getName(this.name);
+    const label = getName(this.name, this.icon);
 
     if (label) {
       this.ariaLabel = label.replace(/\-/g, ' ');

--- a/src/components/pds-icon/readme.md
+++ b/src/components/pds-icon/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                                | Type     | Default     |
-| -------- | --------- | ---------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `color`  | `color`   |  The color of the icon                                                                                     | `string` | `undefined` |
-| `name`   | `name`    | The name of the icon to use from the built-in set.                                                         | `string` | `undefined` |
-| `size`   | `size`    | The size of the icon. This can be 'small', 'regular', 'medium', large, or a custom value (40px, 1rem, etc) | `string` | `'regular'` |
+| Property | Attribute | Description                                                                                                                                                                         | Type     | Default     |
+| -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `color`  | `color`   |  The color of the icon                                                                                                                                                              | `string` | `undefined` |
+| `icon`   | `icon`    | This a combination of both `name` and `src`. If a `src` url is detected it will set the `src` property. Otherwise it assumes it's a built-in named SVG and set the `name` property. | `any`    | `undefined` |
+| `name`   | `name`    | The name of the icon to use from the built-in set.                                                                                                                                  | `string` | `undefined` |
+| `size`   | `size`    | The size of the icon. This can be 'small', 'regular', 'medium', large, or a custom value (40px, 1rem, etc)                                                                          | `string` | `'regular'` |
 
 
 ----------------------------------------------

--- a/src/components/pds-icon/test/pds-icon.spec.ts
+++ b/src/components/pds-icon/test/pds-icon.spec.ts
@@ -72,4 +72,50 @@ describe('pds-icon', () => {
     `);
   });
 
+  it('renders custom aria-label', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsIcon],
+      html: `<pds-icon name="star" aria-label="custom label"></pds-icon>`,
+    });
+
+    expect(root).toEqualHtml(`
+      <pds-icon name="star" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+        <mock:shadow-root>
+          <div class="icon-inner"></div>
+        </mock:shadow-root>
+      </pds-icon>
+    `);
+  });
+
+  it('renders custom label after changing source', async () => {
+    const page = await newSpecPage({
+      components: [PdsIcon],
+      html: `<pds-icon name="youtube" aria-label="custom label"></pds-icon>`,
+    });
+
+    const icon = page.root;
+
+    expect(icon).toEqualHtml(`
+      <pds-icon name="youtube" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+        <mock:shadow-root>
+          <div class="icon-inner"></div>
+        </mock:shadow-root>
+      </pds-icon>
+    `);
+
+    if (icon) {
+      icon.name = 'trash';
+    }
+    await page.waitForChanges();
+
+    expect(icon).toEqualHtml(`
+      <pds-icon name="trash" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+        <mock:shadow-root>
+          <div class="icon-inner"></div>
+        </mock:shadow-root>
+      </pds-icon>
+    `);
+  });
+
+
 });

--- a/src/components/pds-icon/utils.ts
+++ b/src/components/pds-icon/utils.ts
@@ -22,7 +22,15 @@ export const getIconMap = (): Map<string, string> => {
   }
 }
 
-export const getName = (iconName: string | undefined) => {
+export const getName = (
+  iconName: string | undefined,
+  icon: string | undefined
+  ) => {
+
+  if(!iconName && icon && !isSrc(icon)) {
+    iconName = icon;
+  }
+
   if (isStr(iconName)) {
     iconName = toLower(iconName);
   }
@@ -58,11 +66,21 @@ export const getSrc = (src: string | undefined) => {
   return null;
 }
 
-export const getUrl = (icon: PdsIcon) => {
-  const url = getName(icon.name);
+export const getUrl = (pdsIcon: PdsIcon) => {
+  let url = getName(pdsIcon.name, pdsIcon.icon);
   if (url) {
     return getNamedUrl(url);
   }
+
+  if (pdsIcon.icon) {
+    url = getSrc(pdsIcon.icon);
+
+    if(url) {
+      return url;
+    }
+  }
+
+  return null;
 };
 
 


### PR DESCRIPTION
# Description

Adds a new property `icon` for use when being consumed in React.

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This will be tested in a separate PR under the `Pine` repo.

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
