### PR TITLE
ci: change default branch to main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       preid: ${{ inputs.preid || '' }}
-      ref: ${{ inputs.ref || 'next' }}
+      ref: ${{ inputs.ref || 'main' }}
       tag: ${{ inputs.tag || 'nightly' }}
       version: ${{inputs.version || '' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/icon-export.yml
     with:
       preid: ${{ inputs.preid || '' }}
-      ref: ${{ inputs.ref || 'next' }}
+      ref: ${{ inputs.ref || 'main' }}
       tag: ${{ inputs.tag || 'nightly' }}
       version: ${{ inputs.version || '' }}
     secrets: inherit


### PR DESCRIPTION
# Description

This is in preparation for removing from the git-flow branching strategy. We will work off the `main` branch, similar to how things are done in Kajabi Products