### PR TITLE
ci: change tag to be latest for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       preid: ${{ inputs.preid || '' }}
       ref: ${{ inputs.ref || 'main' }}
-      tag: ${{ inputs.tag || 'nightly' }}
+      tag: ${{ inputs.tag || 'latest' }}
       version: ${{inputs.version || '' }}
     secrets: inherit
 


### PR DESCRIPTION
# Description

Update nightly build to tage the latest version to `latest` vs `nightly`.