### PR TITLE
docs(changelog): organize headings and update style for improved look

### DIFF
--- a/scripts/figma_icons/changelog-template.html
+++ b/scripts/figma_icons/changelog-template.html
@@ -1,8 +1,11 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Pine Icons - {{version}} - {{date}} - Changelog</title>
+  <link rel="icon shortcut" type="image/x-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22>
+    <text y=%22.9em%22 font-size=%2290%22>🌲</text>
+  </svg>">
   <style>
     body {
       background-color: #f4f4f4;
@@ -12,14 +15,6 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       font-weight: 400;
       font-style: normal;
-    }
-    h1 { margin: 0; }
-    h2 { margin: 20px 0 0; }
-
-    label {
-      display: inline-block;
-      width: 100px;
-      font-size: 12px;
     }
 
     svg {
@@ -76,11 +71,14 @@
     }
 
     h1 {
+      margin: 0;
       font-family: serif;
       font-size: 60px;
       text-align: center;
-      font-weight: 300;
+      font-weight: 700;
     }
+
+    h2 { margin: 20px 0 0; }
 
     .changelog-dateversion {
       position: relative;
@@ -115,7 +113,7 @@
       <span class="changelog-date">{{date}}</span>
       <span class="changelog-version">{{version}}</span>
     </p>
-    
+
     {{content}}
   </section>
 </body>

--- a/scripts/figma_icons/changelog-template.html
+++ b/scripts/figma_icons/changelog-template.html
@@ -3,14 +3,13 @@
 <head>
   <meta charset="utf-8">
   <title>Pine Icons - {{version}} - {{date}} - Changelog</title>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Hedvig+Letters+Serif|Hedvig+Letters+Sans”>
   <style>
     body {
       background-color: #f4f4f4;
       max-width: 1000px;
       margin-right: auto;
       margin-left: auto;
-      font-family: 'Hedvig Letters Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       font-weight: 400;
       font-style: normal;
     }
@@ -116,15 +115,7 @@
       <span class="changelog-date">{{date}}</span>
       <span class="changelog-version">{{version}}</span>
     </p>
-
-    <p><span class="type-bold">Added icons</span> are new icons introduced in this version. You will not see them in the "before" column because they didn't exist in the previous version.<p>
-
-    <p><span class="type-bold">Modified icons</span> have changed since the previous version. The change could be visual or in the code behind the icon. If the change is visual, you will see the difference between the "before" and "after" columns. If the change is only in the code, the appearance might remain the same, but it will still be listed as "modified."</p>
-
-    <p><span class="type-bold">Deleted icons</span> were present in the previous version but have been removed in this one. You will not see them in the "after" column because they are no longer available.</p>
-
-    <p><span class="type-bold">Renamed icons</span> were present in the previous version but have been renamed in this one. You will see both the "Previous" and "New" filename columns. There will not be any visual changes in the "before" or "after" columns.</p>
-
+    
     {{content}}
   </section>
 </body>

--- a/scripts/figma_icons/changelog-template.html
+++ b/scripts/figma_icons/changelog-template.html
@@ -2,11 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{{date}} - {{version}} Changelog</title>
+  <title>Pine Icons - {{version}} - {{date}} - Changelog</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Hedvig+Letters+Serif|Hedvig+Letters+Sans”>
   <style>
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-      background: #fff;
+      background-color: #f4f4f4;
+      max-width: 1000px;
+      margin-right: auto;
+      margin-left: auto;
+      font-family: 'Hedvig Letters Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      font-weight: 400;
+      font-style: normal;
     }
     h1 { margin: 0; }
     h2 { margin: 20px 0 0; }
@@ -54,28 +60,72 @@
     .type-bold {
       font-weight: bold;
     }
+
+    .changelog-meta {
+      margin-bottom: 30px;
+      font-size: 12px;
+      font-style: italic;
+    }
+
+    section {
+      margin-top: 60px;
+      border-radius: 20px;
+      background: #fff;
+      padding: 30px;
+      box-shadow: 0 5px 5px #ececec;
+      margin-bottom: 60px;
+    }
+
+    h1 {
+      font-family: serif;
+      font-size: 60px;
+      text-align: center;
+      font-weight: 300;
+    }
+
+    .changelog-dateversion {
+      position: relative;
+    }
+
+    .changelog-date {
+      padding: 15px 55px 15px 15px;
+      border: 1px solid gray;
+      background-color: white;
+      border-radius: 4px;
+    }
+
+    .changelog-version {
+      position: absolute;
+      left: 112px;
+      border-radius: 4px;
+      background-color: #71b469;
+      padding: 5px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: #fff;
+      font-weight: 300;
+    }
   </style>
 </head>
 <body>
-<h1>{{date}} - {{version}} Changelog</h1>
+  <section>
+    <h1>Pine Icons - Changelog</h1>
+    <p class="changelog-meta">Icons: Added <span class="type-bold">{{created}}</span>, Modifed <span class="type-bold">{{modified}}</span>, Deleted <span class="type-bold">{{deleted}}</span>, Renamed <span class="type-bold">{{renamed}}</span></p>
 
-Files: Modifed <span class="type-bold">{{modified}}</span>, Renamed <span class="type-bold">{{renamed}}</span>, Deleted <span class="type-bold">{{deleted}}</span>, Created <span class="type-bold">{{created}}</span>
+    <p class="changelog-dateversion">
+      <span class="changelog-date">{{date}}</span>
+      <span class="changelog-version">{{version}}</span>
+    </p>
 
+    <p><span class="type-bold">Added icons</span> are new icons introduced in this version. You will not see them in the "before" column because they didn't exist in the previous version.<p>
 
-<h2>Info</h2>
-<p>Added icons are new icons that have been introduced in this version. You won't see these icons listed in the "before" column because they did not exist in the previous version.<p>
+    <p><span class="type-bold">Modified icons</span> have changed since the previous version. The change could be visual or in the code behind the icon. If the change is visual, you will see the difference between the "before" and "after" columns. If the change is only in the code, the appearance might remain the same, but it will still be listed as "modified."</p>
 
-<p>Modified icons have undergone some changes since the previous version, which could be a visual change or a change to the code behind the icon. If an icon has undergone a visible change,
-you will see the difference between the "before" and "after" columns. However, if the change was only to the code, you may not notice any difference in the icon's appearance, but it will
-still be listed in the “modified” category</p>
+    <p><span class="type-bold">Deleted icons</span> were present in the previous version but have been removed in this one. You will not see them in the "after" column because they are no longer available.</p>
 
-<p>Deleted icons were present in the previous version but have been removed in this version. You will not see these icons listed in the "after" column because they are no longer available
-in the current version.</p>
+    <p><span class="type-bold">Renamed icons</span> were present in the previous version but have been renamed in this one. You will see both the "Previous" and "New" filename columns. There will not be any visual changes in the "before" or "after" columns.</p>
 
-<p>Renamed icons were present in the previous version but have been renamed in this version. You will see a "Previous" and a "New" filename column. You will not see any visual change
-in the "before" or "after" column.</p>
-
-{{content}}
-
+    {{content}}
+  </section>
 </body>
 </html>

--- a/scripts/figma_icons/figma-icon-export.ts
+++ b/scripts/figma_icons/figma-icon-export.ts
@@ -1,6 +1,6 @@
 import * as dotenv from 'dotenv';
 
-import { run as optimizeSvgs} from '../optimize-svgs'
+import { run as optimizeSvgs } from '../optimize-svgs'
 import { collectionCopy } from '../collection-copy';
 
 
@@ -10,13 +10,13 @@ import chalk from 'chalk'; // Terminal string styling done right
 import path from 'path';
 import fs from 'fs-extra';
 import mkdirp from 'mkdirp';
-import cliui  from 'cliui';
+import cliui from 'cliui';
 import { simpleGit, SimpleGitOptions, StatusResult } from 'simple-git';
 
 import { FigmaIcon, FigmaIconConfig, IconFileDetail, SvgDiffResult } from './types';
 
 if (process.env.NODE_ENV !== 'prod') {
-  dotenv.config({ path: `${process.cwd()}/.env` })
+  dotenv.config({ path: `${process.cwd()}/.env` });
 }
 
 
@@ -209,7 +209,7 @@ const client = (apiToken) => {
  * @returns The results from SimpleGit.status()
  */
 const createChangelogHTML = async (statusResults: StatusResult) => {
-  const {modified, created, deleted, renamed} =  await processStatusResults(statusResults);
+  const { modified, created, deleted, renamed } = await processStatusResults(statusResults);
 
   // Adding or Deleting will be Major version bump
   // Modifying will be a MINOR version bump
@@ -231,7 +231,7 @@ const createChangelogHTML = async (statusResults: StatusResult) => {
 
   const arrChangelogs = fs.readdirSync(changelogPath);
 
-  const changelogRecords = []
+  const changelogRecords = [];
   let numberOfChangelogs = 0;
 
   arrChangelogs.reverse().forEach((filename, idx) => {
@@ -287,7 +287,7 @@ const createChangelogHTML = async (statusResults: StatusResult) => {
  */
 const createJsonIconList = (icons: Array<FigmaIcon>, outputDir: string) => {
   try {
-    icons = icons.sort((a,b) => {
+    icons = icons.sort((a, b) => {
       if (a.name < b.name) return -1;
       if (a.name > b.name) return 1;
       return 0;
@@ -353,7 +353,7 @@ const createOutputDirectory = async (outputDir: string) => {
  * @returns a object with the name and size of the svg
  */
 const downloadImage = (icon: FigmaIcon, outputDir: string) => {
-  const nameClean = icon.name.toLowerCase();;
+  const nameClean = icon.name.toLowerCase();
   const directory = outputDir;
 
   const imagePath = path.resolve(directory, `${nameClean}.svg`);
@@ -362,7 +362,7 @@ const downloadImage = (icon: FigmaIcon, outputDir: string) => {
   // log('Image url: ', info(icon.url), 'Frame: ', info(icon.frame));
   // log('Image Path: ', info(imagePath));
 
-  axios.get(icon.url, {responseType: 'stream'})
+  axios.get(icon.url, { responseType: 'stream' })
     .then((res) => {
       res.data.pipe(writer)
     })
@@ -560,7 +560,7 @@ const getFileContentsFromDisk = async (filename: string) => {
  * @param options - list of SimpleGitOptions
  * @returns SimpleGit client
  */
- const gitClient = (options: Partial<SimpleGitOptions> = {baseDir: srcSvgBasePath, binary: 'git'} ) => {
+const gitClient = (options: Partial<SimpleGitOptions> = { baseDir: srcSvgBasePath, binary: 'git' } ) => {
   return simpleGit(options);
  }
 
@@ -574,7 +574,7 @@ const loadFigmaIconConfig = async (rootDir: string) => {
   try {
     const configFile =  path.resolve(path.join(rootDir, 'figma-icon-config.json'));
 
-    if ( fs.existsSync(configFile)) {
+    if (fs.existsSync(configFile)) {
       log(info('Config file located at: ', detail(configFile)));
 
       const strConfig = await fs.readFile(configFile, 'utf-8');
@@ -654,7 +654,7 @@ const processStatusResults = async (results: StatusResult) => {
 
   if (n.length > 0) {
     created = await Promise.all(n.map((path) => { return buildBeforeAndAfterSvg('', path)}));
-    created = buildHTMLSection('Added', created, 'New icons introduced in this version. You will not see them in the "before" column because they didn not exist in the previous version.');
+    created = buildHTMLSection('Added', created, 'New icons introduced in this version. You will not see them in the "before" column because they did not exist in the previous version.');
   }
 
   if (d.length > 0) {


### PR DESCRIPTION
# Description
* Updated CSS for style changes and modified HTML to fit accordingly. 
* Modified the JS to include descriptions for sections that are present and along with those sections.

## Screenshots
| Before    | After |
| -------- | ------- |
|  ![Screenshot 2024-05-07 at 10 25 59 AM](https://github.com/Kajabi/pine-icons/assets/24237393/14d16c82-66b9-4747-a955-f024f57bfcf9) |  ![Screenshot 2024-05-09 at 3 04 43 PM](https://github.com/Kajabi/pine-icons/assets/24237393/aa7ac45c-74a6-4c93-9559-f4afe8051f35) |


## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Documentation improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
