### PR TITLE
fix: adds missing alt to icon

### DIFF
--- a/src/components/pds-icon/pds-icon.tsx
+++ b/src/components/pds-icon/pds-icon.tsx
@@ -126,6 +126,7 @@ export class PdsIcon {
 
       <Host
         aria-label={ariaLabel !== undefined && !this.hasAriaHidden() ? ariaLabel : null }
+        alt=""
         role="img"
         style={style}
         class={{

--- a/src/components/pds-icon/test/pds-icon.e2e.ts
+++ b/src/components/pds-icon/test/pds-icon.e2e.ts
@@ -4,7 +4,7 @@ describe('pds-icon', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<pds-icon role="img" style="height: 16px; width: 16px;"></pds-icon>');
+    await page.setContent('<pds-icon alt="" role="img" style="height: 16px; width: 16px;"></pds-icon>');
     const element = await page.find('pds-icon');
     expect(element).toHaveClass('hydrated');
   });

--- a/src/components/pds-icon/test/pds-icon.spec.ts
+++ b/src/components/pds-icon/test/pds-icon.spec.ts
@@ -8,7 +8,7 @@ describe('pds-icon', () => {
       html: '<pds-icon></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon role="img" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" role="img" size="regular" style="height: 16px; width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -22,7 +22,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="small"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon role="img" size="small" style="height: 12px; width: 12px;">
+      <pds-icon alt="" role="img" size="small" style="height: 12px; width: 12px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -36,7 +36,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="32px"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon role="img" size="32px" style="height: 32px; width: 32px;">
+      <pds-icon alt="" role="img" size="32px" style="height: 32px; width: 32px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -50,7 +50,7 @@ describe('pds-icon', () => {
       html: '<pds-icon name="archive"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon aria-label="archive" name="archive" role="img" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" aria-label="archive" name="archive" role="img" size="regular" style="height: 16px; width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>


### PR DESCRIPTION
# Description

During accessibility testing scans the icon was noted as missing `alt` attribute that is required since it has `role="img"`

Fixes

```
Ensure [role="img"] elements have alternate text
```


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
