### PR TITLE
feat: size prop now sets css variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4479,6 +4479,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pine-ds/icons": {
+      "resolved": "",
+      "link": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -11023,6 +11027,41 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -11035,6 +11074,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-circus/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {

--- a/src/components/pds-icon/pds-icon.scss
+++ b/src/components/pds-icon/pds-icon.scss
@@ -1,12 +1,16 @@
 :host {
+  --dimension-icon-height: 16px;
+  --dimension-icon-width: 16px;
+  --color-icon-fill: currentColor;
+
   contain: strict;
   display: inline-block;
-  fill: currentColor;
-  height: 1em;
-  width: 1em;
+  fill: var(--color-icon-fill);
+  height: var(--dimension-icon-height);
+  width: var(--dimension-icon-width);
 
   .pdsicon {
-    fill: currentColor;
+    fill: var(--color-icon-fill);
   }
 }
 

--- a/src/components/pds-icon/pds-icon.tsx
+++ b/src/components/pds-icon/pds-icon.tsx
@@ -73,8 +73,20 @@ export class PdsIcon {
       return this.size;
     }
   }
+
+  componentDidLoad() {
+    this.setCSSVariables();
+  }
+
   componentWillLoad() {
     this.inheritedAttributes = inheritAttributes(this.el, ['aria-label']);
+    this.setCSSVariables();
+  }
+
+  setCSSVariables() {
+    this.el.style.setProperty(`--dimension-icon-height`, this.iconSize());
+    this.el.style.setProperty(`--dimension-icon-width`, this.iconSize());
+    this.el.style.setProperty(`--color-icon-fill`, this.color);
   }
 
   connectedCallback() {
@@ -116,19 +128,12 @@ export class PdsIcon {
   render() {
     const { ariaLabel, inheritedAttributes } = this;
 
-    const style = {
-      height: this.iconSize(),
-      width: this.iconSize(),
-      color: this.color,
-    }
-
     return (
 
       <Host
         aria-label={ariaLabel !== undefined && !this.hasAriaHidden() ? ariaLabel : null }
         alt=""
         role="img"
-        style={style}
         class={{
           ...createColorClasses(this.color),
         }}

--- a/src/components/pds-icon/test/pds-icon.spec.ts
+++ b/src/components/pds-icon/test/pds-icon.spec.ts
@@ -8,7 +8,7 @@ describe('pds-icon', () => {
       html: '<pds-icon></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -22,7 +22,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="small"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="small" style="height: 12px; width: 12px;">
+      <pds-icon alt="" role="img" size="small" style="--dimension-icon-height: 12px; --dimension-icon-width: 12px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -36,7 +36,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="32px"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="32px" style="height: 32px; width: 32px;">
+      <pds-icon alt="" role="img" size="32px" style="--dimension-icon-height: 32px; --dimension-icon-width: 32px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -50,7 +50,7 @@ describe('pds-icon', () => {
       html: '<pds-icon name="archive"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" aria-label="archive" name="archive" role="img" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" aria-label="archive" name="archive" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -64,7 +64,7 @@ describe('pds-icon', () => {
       html: '<pds-icon name="archive" color="red"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" aria-label="archive" class="pds-color pds-color-red" color="red" name="archive" role="img" size="regular" style="height: 16px; width: 16px; color: red">
+      <pds-icon alt="" aria-label="archive" class="pds-color pds-color-red" color="red" name="archive" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: red">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -79,7 +79,7 @@ describe('pds-icon', () => {
     });
 
     expect(root).toEqualHtml(`
-      <pds-icon alt="" name="star" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" name="star" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -96,7 +96,7 @@ describe('pds-icon', () => {
     const icon = page.root;
 
     expect(icon).toEqualHtml(`
-      <pds-icon alt="" name="youtube" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" name="youtube" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -109,7 +109,7 @@ describe('pds-icon', () => {
     await page.waitForChanges();
 
     expect(icon).toEqualHtml(`
-      <pds-icon alt="" name="trash" role="img" aria-label="custom label" size="regular" style="height: 16px; width: 16px;">
+      <pds-icon alt="" name="trash" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
 
     <script type="module" src="/build/pds-icons.esm.js"></script>
     <script nomodule src="/build/pds-icons.js"></script>
+    <style>
+      .something { height: 120px; width: 120px; }
+    </style>
   </head>
   <body>
     <h1>Pine Icons</h1>
@@ -29,6 +32,10 @@
 
     <h3>Custom size</h3>
     <pds-icon name="youtube" size="140px"></pds-icon>
+
+    <h3>Custom size with class</h3>
+    <p>Style will override the size of 20px and be set to 120px</p>
+    <pds-icon name="pen" size="20px" class="something"></pds-icon>
 
     <h3>Color</h3>
     <pds-icon name="youtube" size="140px" color="red"></pds-icon>


### PR DESCRIPTION
# Description
The size property was setting values in the Style attribute, preventing Devs from targeting and sizing the specific attribute.

With this change, a custom class can be applied and will take precedence over the style. 

![image](https://github.com/user-attachments/assets/8cc96491-9d6b-4cac-a9c4-055b81885de9)
![image](https://github.com/user-attachments/assets/cb511b95-721d-4324-b1cf-56d9809be53d)

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
