### PR TITLE
test: fix failing specs due to missing CSS Custom Prop

### DIFF
--- a/src/components/pds-icon/test/pds-icon.spec.ts
+++ b/src/components/pds-icon/test/pds-icon.spec.ts
@@ -8,7 +8,7 @@ describe('pds-icon', () => {
       html: '<pds-icon></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
+      <pds-icon alt="" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -22,7 +22,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="small"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="small" style="--dimension-icon-height: 12px; --dimension-icon-width: 12px;">
+      <pds-icon alt="" role="img" size="small" style="--dimension-icon-height: 12px; --dimension-icon-width: 12px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -36,7 +36,7 @@ describe('pds-icon', () => {
       html: '<pds-icon size="32px"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" role="img" size="32px" style="--dimension-icon-height: 32px; --dimension-icon-width: 32px;">
+      <pds-icon alt="" role="img" size="32px" style="--dimension-icon-height: 32px; --dimension-icon-width: 32px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -50,7 +50,7 @@ describe('pds-icon', () => {
       html: '<pds-icon name="archive"></pds-icon>',
     });
     expect(root).toEqualHtml(`
-      <pds-icon alt="" aria-label="archive" name="archive" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
+      <pds-icon alt="" aria-label="archive" name="archive" role="img" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -79,7 +79,7 @@ describe('pds-icon', () => {
     });
 
     expect(root).toEqualHtml(`
-      <pds-icon alt="" name="star" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
+      <pds-icon alt="" name="star" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -96,7 +96,7 @@ describe('pds-icon', () => {
     const icon = page.root;
 
     expect(icon).toEqualHtml(`
-      <pds-icon alt="" name="youtube" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
+      <pds-icon alt="" name="youtube" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>
@@ -109,7 +109,7 @@ describe('pds-icon', () => {
     await page.waitForChanges();
 
     expect(icon).toEqualHtml(`
-      <pds-icon alt="" name="trash" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px;">
+      <pds-icon alt="" name="trash" role="img" aria-label="custom label" size="regular" style="--dimension-icon-height: 16px; --dimension-icon-width: 16px; --color-icon-fill: currentColor;">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>


### PR DESCRIPTION
# Description

Icon specs were failing due to missing CSS Custom Property

Fixes #(issue)

## Type of change
- [X] Test

# How Has This Been Tested?

- [x] unit tests

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
