### PR TITLE
style(icons): add flex shrink none to base icons

### DIFF
--- a/src/components/pds-icon/pds-icon.scss
+++ b/src/components/pds-icon/pds-icon.scss
@@ -6,6 +6,7 @@
   contain: strict;
   display: inline-block;
   fill: var(--color-icon-fill);
+  flex-shrink: 0;
   height: var(--dimension-icon-height);
   width: var(--dimension-icon-width);
 


### PR DESCRIPTION
# Description
Icons are shrinking when the adjacent element has enough text to wrap to another line

Fixes #(issue)

|  Before  |  After  |
|--------|--------|
|<img width="345" alt="Screenshot 2025-04-02 at 9 56 31 AM" src="https://github.com/user-attachments/assets/b35881bb-07be-41d5-b77f-b76eeabd5e54" />|<img width="344" alt="Screenshot 2025-04-02 at 9 56 53 AM" src="https://github.com/user-attachments/assets/3d96926a-06bb-42f8-b858-834c0853cb88" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Parent element that has `display: flex`
- One of the children is `pds-icon`
- At least one other child has text
- When the text wraps, it causes the icon to shrink <- the important part
- This reduces the icon shrinking lower than it's specified size 

### Method

- [x] tested manually


**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
