### PR TITLE
fix: changes the location which we should look for svgs

### DIFF
--- a/scripts/collection-copy.ts
+++ b/scripts/collection-copy.ts
@@ -5,16 +5,12 @@ export const collectionCopy = async (rootDir: string) => {
   const optimizedSrc = join(rootDir, 'src', 'svg');
   const distSvgDest = join(rootDir, 'dist', 'svg');
   const collectionDest = join(rootDir, 'dist', 'collection', 'components', 'pds-icon', 'svg');
-  const pdsIconsSvgDest = join(rootDir, 'dist', 'pds-icons', 'svg');
 
   await fs.copy(optimizedSrc, collectionDest);
   console.log('Copied optimized SVGs to collection: ', collectionDest);
 
   await fs.copy(optimizedSrc, distSvgDest);
   console.log('Copied optimized SVGs to dist/svg: ', distSvgDest);
-
-  await fs.copy(optimizedSrc, pdsIconsSvgDest);
-  console.log('Copied optimized SVGs to dist/pds-icons/svg: ', pdsIconsSvgDest);
 
   // we don't want to copy the src/svgs to the collection (distribution)
   await fs.remove(join(rootDir, 'dist', 'collection', 'svg'));

--- a/src/components/pds-icon/assetPath.ts
+++ b/src/components/pds-icon/assetPath.ts
@@ -24,7 +24,7 @@ export const getAssetPath = (path: string) => {
   const windowAssetPath = window.__PINE_ASSET_PATH__;
 
   // Set the CDN Asset path using the latest version
-  const cdnAssetPath = 'https://cdn.jsdelivr.net/npm/@pine-ds/icons/dist/pds-icons/';
+  const cdnAssetPath = 'https://cdn.jsdelivr.net/npm/@pine-ds/icons/';
 
   const assetBasePath  = Build.isTesting ? '/dist/pds-icons' : metaPineAssetPath || windowAssetPath || cdnAssetPath || '/'
 


### PR DESCRIPTION

# Description

SVGs are not always copied to the path from which they should be read. I have updated the CDN path, hoping this should resolve intermittent issues depending on the deployment type.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Additional Notes
- We will need to revert the changes made in this [PR](https://github.com/Kajabi/kajabi-products/pull/41850)
- 
# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
