### PR TITLE
chore: configure Dependabot for GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 # Global owners
 
 - @Kajabi/dss-devs
+/.github/ @kajabi/production-engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Configures Dependabot to keep GitHub Actions versions up to date in this repo, generated by `bin/configure-dependabot` (gh-org).

## Changes

- Creates `.github/dependabot.yml` with a weekly `package-ecosystem: github-actions` entry, grouped via `groups.github-actions.patterns: ["*"]`.
- Updates `.github/CODEOWNERS` to add `@kajabi/production-engineering` as a codeowner of `/.github/`.

## Why

GitHub deprecated the Node 20 runtime in June 2026. Repos pinning action versions on Node 20 (e.g. `actions/checkout@v4`) start emitting deprecation warnings and eventually fail. Dependabot keeps these refs current automatically so we don't have to chase the next runtime sunset by hand.

Adding `@kajabi/production-engineering` as a codeowner of `/.github/` ensures the right team is auto-requested for review on the weekly Dependabot PRs (and any other future automation under `.github/`).

Source rules and history live in [Kajabi/gh-org](https://github.com/Kajabi/gh-org).
