### PR TITLE
ci(release): pin slack-github-action back to v1.26.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           echo "COMMIT_MESSAGE=$(git log --pretty=format:%s -n 1 HEAD~)" >> $GITHUB_ENV
 
       - name: Send Slack Notification
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           DATE: ${{ env.CURRENT_DATE }}


### PR DESCRIPTION
## Problem

The **Pine Nightly Automations** run fails every night on the `send-slack-notification` job:

```
Warning: Unexpected input(s) 'channel-id', valid inputs are ['api', 'errors', 'method',
  'payload', 'payload-delimiter', 'retries', 'token', 'webhook', 'webhook-type']
Error: Missing input! Either a method or webhook is required to take action.
```

The icon work itself (`update-icons`, `release-changes`) succeeds — only the Slack notification fails, so the run shows red and the team stops getting the release ping.

## Root cause

Dependabot #51 (`chore(deps): bump the github-actions group`) bumped `slackapi/slack-github-action` **v1.26.0 → v3.0.3**, a breaking major-version change. The v3 API removed the v1 inputs this step uses (`channel-id`, `payload-file-path`) and now requires either a `method` (e.g. `chat.postMessage` + `token` + `payload`) or a `webhook` + `webhook-type`. The step was never migrated, so it fails input validation on every run.

## Fix

Pin the action back to `v1.26.0`, which matches the existing v1-style step config. This restores the working notification with no other changes.

## Follow-up

Migrating the step to the v3 `method`/`payload` API (moving the channel into the payload JSON) should be a separate PR that can be validated with a real run, rather than bundled into this stop-the-bleeding revert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin with no application or runtime behavior changes; restores previously working notification config.
> 
> **Overview**
> Reverts the **Send Slack Notification** step in `release.yml` from `slackapi/slack-github-action@v3.0.3` to **`v1.26.0`**, so the existing v1 inputs (`channel-id`, `payload-file-path`) and env-based bot token setup work again.
> 
> This fixes nightly **Pine Nightly Automations** failures where the release job succeeded but Slack notification died on v3’s incompatible input schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fbbc713680391d3e4539fcbfd2ba1e1cf24c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->