### PR TITLE
ci(release): migrate Send Slack Notification to slack-github-action v3 API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,12 +141,15 @@ jobs:
       - name: Send Slack Notification
         uses: slackapi/slack-github-action@v3.0.3
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: ${{ vars.SLACK_CHANNEL_NAME }}
           DATE: ${{ env.CURRENT_DATE }}
           RELEASE_URL: "${{ format('https://github.com/{0}/releases/tag/v{1}', github.repository, fromJSON(env.PACKAGE_JSON).version) }}"
           CHANGELOG_URL: "${{ format('https://pine-icons.netlify.app/changelogs/{0}-changelog.html', env.CURRENT_DATE) }}"
           VERSION: ${{ fromJson(env.PACKAGE_JSON).version }}
           COMMIT_MESSAGE: ${{ env.COMMIT_MESSAGE }}
         with:
-          channel-id: ${{ vars.SLACK_CHANNEL_NAME }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          payload-templated: true
           payload-file-path: "./.github/workflows/slack_payloads/release-info.json"

--- a/.github/workflows/slack_payloads/release-info.json
+++ b/.github/workflows/slack_payloads/release-info.json
@@ -1,4 +1,6 @@
 {
+	"channel": "${{ env.CHANNEL_ID }}",
+	"text": ":pine: Pine Icon Release v${{ env.VERSION }}",
 	"blocks": [
 		{
 			"type": "header",


### PR DESCRIPTION
## Problem

Dependabot #51 bumped `slackapi/slack-github-action` **v1.26.0 → v3.0.3**, a breaking major change. The v3 technique-based API removed the v1 inputs the `send-slack-notification` step used, so every nightly failed with:

```
Error: Missing input! Either a method or webhook is required to take action.
```

(Icon export/release themselves were unaffected — only the notification.)

## Fix — migrate to the v3 API

| v1 | v3 |
|----|----|
| `channel-id:` input | `channel` field **inside the payload** (via `CHANNEL_ID` env) |
| `SLACK_BOT_TOKEN` env | `method: chat.postMessage` + `token:` inputs |
| implicit templating | `payload-templated: true` (keeps existing `${{ env.* }}` refs) |

Plus two hardening changes:
- **`errors: true`** — v3 defaults to `false`, which would let a failed post pass green and go unnoticed. This was the exact failure mode that hid nothing here only because it happened at input-validation; a runtime Slack error (bad channel, bot removed) would be silent. `errors: true` keeps notification failures loud.
- **top-level `text` fallback** in the payload — a11y / notification-preview best practice; also silences the Slack SDK warning about a blocks-only payload.

## Verification (end-to-end, not just YAML-valid)

Ran the exact step config in a real GitHub Actions runner against `#dss-inbox` (real `SLACK_BOT_TOKEN` + `SLACK_CHANNEL_NAME`), on a throwaway branch, **with `errors: true`** — so a green run is machine-proof Slack returned `ok: true`:
- `vars.SLACK_CHANNEL_NAME` resolved to `dss-inbox` ✓
- all `${{ env.* }}` payload refs templated correctly ✓
- run **green with `errors: true`** → message accepted and posted ✓

Throwaway verify workflow lived only on a temp branch (never on `main` or this branch) and has been deleted.

## Note

Supersedes the #54 revert stop-gap (now closed). This lands the durable fix directly and also closes the Dependabot loop — the group already sits at v3.0.3, so there's nothing left to re-bump-and-break.