### PR TITLE
ci(release): fail the release job when npm publish does not land

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Guard against `nx release` exiting 0 even when its npm publish phase
+      # fails. Without this, a broken publish (e.g. an expired NPM_TOKEN) still
+      # tags the version and writes the changelog, so the job reads green while
+      # nothing reaches npm — which is exactly how 10.1.0 and 10.2.0 were
+      # tagged but never published. See DSS-215.
+      - name: Verify npm publish landed
+        shell: bash
+        run: |
+          PKG=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Verifying ${PKG}@${VERSION} is available on npm…"
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
+              echo "✓ ${PKG}@${VERSION} confirmed on npm"
+              exit 0
+            fi
+            echo "  not visible yet (attempt ${attempt}/6), waiting 10s…"
+            sleep 10
+          done
+          echo "::error::${PKG}@${VERSION} was NOT published to npm. The release step exited 0 but the publish phase did not land — check the nx-release-publish output above and the NPM_TOKEN secret."
+          exit 1
+
   send-slack-notification:
     runs-on: ubuntu-latest
     needs: release-changes


### PR DESCRIPTION
## Why

`pine-icons` tagged **v10.1.0** (2026-06-16) and **v10.2.0** (2026-07-28), cut GitHub Releases, and published changelog pages for both — but **neither reached npm**. `latest` sat at `10.0.0` for ~3.5 months and consumers silently stopped getting new icons (e.g. `inbox-tone`).

Root cause of the silence: `npx nx release --yes` runs **version → changelog → publish** as one command and **exits 0 even when the publish phase fails**. Version + changelog have already committed the tag and written the changelog by the time `nx-release-publish` errors (`npm publish error: … tarball, folder, http url, or git url.`), so the job reads **green** while nothing lands on npm. The only visible red on recent nightlies was an unrelated Slack-action issue (already fixed on main in #55), which masked this.

[Failed nightly that tagged 10.2.0 with a ❌ publish but a green job.](https://github.com/Kajabi/pine-icons/actions/runs/30355689553)

## What this PR does

Adds a **`Verify npm publish landed`** step after the release steps. It reads the just-released name/version from `package.json` and polls npm; if the version isn't visible after 6 tries it fails the job with a clear `::error::`. A broken publish can no longer read green.

```yaml
- name: Verify npm publish landed
  shell: bash
  run: |
    PKG=$(node -p "require('./package.json').name")
    VERSION=$(node -p "require('./package.json').version")
    ...poll `npm view "$PKG@$VERSION"`; exit 1 with an ::error:: if never visible
```

## What this PR does NOT do

- It does **not** fix the underlying publish failure. That is almost certainly an **expired/invalid `NPM_TOKEN`** secret (the DSS automation token, orphaned when the team wound down — same bus-factor pattern as the pine/ds-tokens CODEOWNERS cleanup). Rotating that secret is tracked in **DSS-215** and needs npm-org admin access, not a code change.
- It does not restructure the nx release wiring — the guard is intentionally minimal and additive.

## Immediate mitigation (already done)

`@pine-ds/icons@10.2.0` was manually built from a clean `v10.2.0` checkout and published on 2026-08-03; `latest` now = `10.2.0`. `10.1.0` was left unpublished (superseded).

## Testing

- YAML step mirrors the indentation/shape of the existing steps in the job.
- Can't fully exercise in this PR without cutting a release; the polling logic is a plain `npm view` existence check with backoff. Reviewer sanity-check welcome.

Ref: DSS-215

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additive guard with no runtime or publish logic changes; only affects release job success when npm publish silently fails.
> 
> **Overview**
> Adds a **Verify npm publish landed** step to the production release workflow immediately after both `nx release` paths. It reads `name` and `version` from `package.json`, polls `npm view` up to six times with 10s backoff, and **fails the job** with a GitHub `::error::` if the version never appears on npm.
> 
> This guards against `npx nx release --yes` exiting successfully after version/changelog work even when the publish phase fails (e.g. bad `NPM_TOKEN`), so releases can no longer show green while consumers never get the package on npm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89bc411ce905f38430578f7839ea7e0bb726765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->